### PR TITLE
fixing incorrectly located todo comment.

### DIFF
--- a/src/routes/+page.svx
+++ b/src/routes/+page.svx
@@ -35,8 +35,8 @@
   let cookieChange = $derived(page.data.visited ? 'back' : '');
 </script>
 
-<!--Modal bind:open={defaultModel} size={"xs"} dismissable={false}>
 <!--HACK: #309 Decide if I actually want this -->
+<!--Modal bind:open={defaultModel} size={"xs"} dismissable={false}>
 <div class="flex flex-col justify-center items-stretch bg-bravegrumpy-accent2a dark:bg-bravegrumpy-black dark:text-bravegrumpy-accent2a rounded-[5px] border-[2px] border-solid border-current text-bravegrumpy-black w-4/5 mx-auto p-5">
 
 I agree that I am over the age of 18 and consent to being exposed to adult content


### PR DESCRIPTION
Fixing a malformed comment, causing problems.
AKA don't put an HTML comment inside of another HTML comment.